### PR TITLE
FindBugsMojo: default locale, not hardcode pt.BR

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/findbugs/FindBugsMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/findbugs/FindBugsMojo.groovy
@@ -695,7 +695,7 @@ class FindBugsMojo extends AbstractMavenReport {
     public void execute() {
         log.debug("****** FindBugsMojo execute *******")
 
-        Locale locale = new Locale("pt", "BR")
+        Locale locale = Locale.getDefault()
         if (!skip) {
             executeCheck(locale)
             if (canGenerateReport()) {


### PR DESCRIPTION
It does not seem to make sense to hard-code the Brazilian Portuguese locale.
Let's try it with the default locale.
